### PR TITLE
feat: backend source filtering and stronger lexical retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It focuses on an unmet need: **Ikhtilaf-aware pedagogy**. Instead of a single fl
 - `POST /v1/ask`
 - `POST /v1/quiz/generate`
 - `POST /v1/quiz/grade`
+- `GET /v1/sources` (with optional `language`, `topic`, `q` filters)
 - `GET /v1/sources/{id}`
 - `GET /v1/health/retrieval`
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -11,9 +11,10 @@ from app.schemas import (
     RetrievalHealthResponse,
     SessionCreateRequest,
     SessionCreateResponse,
+    SourceListResponse,
     SourceDocument,
 )
-from app.services.catalog import count_passages_in_db, load_catalog
+from app.services.catalog import count_passages_in_db, filter_sources, load_catalog
 from app.services.citation import CitationValidator
 from app.services.learning import SessionManager
 from app.services.quiz import QuizService
@@ -89,6 +90,16 @@ def get_source(source_id: str):
     if not source:
         raise HTTPException(status_code=404, detail="Source not found")
     return source
+
+
+@router.get("/sources", response_model=SourceListResponse)
+def list_sources(
+    language: str | None = None,
+    topic: str | None = None,
+    q: str | None = None,
+):
+    items = filter_sources(language=language, topic=topic, q=q)
+    return SourceListResponse(items=items, total=len(items))
 
 
 @router.get("/health/retrieval", response_model=RetrievalHealthResponse)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -31,6 +31,11 @@ class SourceDocument(BaseModel):
     citation_policy: str
 
 
+class SourceListResponse(BaseModel):
+    items: List[SourceDocument] = Field(default_factory=list)
+    total: int
+
+
 class Passage(BaseModel):
     id: str
     source_document_id: str

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -83,6 +83,21 @@ def test_source_lookup() -> None:
         assert r.json()["id"] == "src_quran_49_13"
 
 
+def test_source_list_filtering() -> None:
+    with get_client() as client:
+        all_sources = client.get("/v1/sources")
+        assert all_sources.status_code == 200
+        assert all_sources.json()["total"] >= 1
+
+        fiqh_sources = client.get("/v1/sources?topic=fiqh")
+        assert fiqh_sources.status_code == 200
+        assert fiqh_sources.json()["total"] >= 1
+
+        ar_sources = client.get("/v1/sources?language=ar")
+        assert ar_sources.status_code == 200
+        assert ar_sources.json()["total"] >= 1
+
+
 def test_quiz_updates_mastery() -> None:
     with get_client() as client:
         session = client.post(


### PR DESCRIPTION
## Summary
- add `GET /v1/sources` with `language`, `topic`, and `q` filters
- improve Arabic/English lexical normalization in retriever
- extend API tests for source list filtering
- update README API list

## Validation
- `pytest backend/tests -q`
- `npm run lint`
- `npm run typecheck`