### PR TITLE
chore: harden CI with lint, coverage, and smoke tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ./backend[dev]
+      - name: Lint backend
+        run: ruff check backend/app backend/tests
       - name: Run backend tests
-        run: pytest backend/tests -q
+        run: pytest backend/tests --cov=backend/app --cov-report=term-missing -q
 
   frontend:
     runs-on: ubuntu-latest
@@ -36,3 +38,5 @@ jobs:
         run: npm run lint
       - name: Typecheck frontend
         run: npm run typecheck
+      - name: Build frontend
+        run: npm run build

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: backend-install backend-test backend-run frontend-install frontend-run fmt
+.PHONY: backend-install backend-lint backend-test backend-cov backend-run frontend-install frontend-run smoke
 
 backend-install:
 	cd backend && python3 -m venv .venv && . .venv/bin/activate && pip install -e .[dev]
 
+backend-lint:
+	cd backend && . .venv/bin/activate && ruff check app tests
+
 backend-test:
 	cd backend && . .venv/bin/activate && pytest tests -q
+
+backend-cov:
+	cd backend && . .venv/bin/activate && pytest tests --cov=app --cov-report=term-missing -q
 
 backend-run:
 	cd backend && . .venv/bin/activate && uvicorn app.main:app --reload
@@ -14,3 +20,6 @@ frontend-install:
 
 frontend-run:
 	cd frontend && npm run dev
+
+smoke:
+	./scripts/smoke_backend.sh

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ npm run dev
 
 The frontend expects backend at `http://localhost:8000`.
 
+## Quality Gates (Local)
+
+```bash
+make backend-lint
+make backend-cov
+cd frontend && npm run lint && npm run typecheck && npm run build
+```
+
+With backend running:
+
+```bash
+make smoke
+```
+
 ## Open-Source / Free Tooling
 
 - FastAPI + Pydantic + SQLModel

--- a/backend/app/agents/pipeline.py
+++ b/backend/app/agents/pipeline.py
@@ -5,7 +5,13 @@ from typing import List, Optional, TypedDict
 from langgraph.graph import END, START, StateGraph
 
 from app.core.config import settings
-from app.schemas import AskResponse, EvidenceCard, LearningObjective, OpinionComparisonItem, TopicIntent
+from app.schemas import (
+    AskResponse,
+    EvidenceCard,
+    LearningObjective,
+    OpinionComparisonItem,
+    TopicIntent,
+)
 from app.services.learning import SessionManager
 from app.services.retrieval import HybridRetriever, RetrievalResult
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,6 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException
 
-from app.api.deps import get_citation_validator, get_pipeline, get_quiz_service, get_retriever, get_sessions
+from app.api.deps import (
+    get_citation_validator,
+    get_pipeline,
+    get_quiz_service,
+    get_retriever,
+    get_sessions,
+)
 from app.schemas import (
     AskRequest,
     AskResponse,
@@ -11,8 +17,8 @@ from app.schemas import (
     RetrievalHealthResponse,
     SessionCreateRequest,
     SessionCreateResponse,
-    SourceListResponse,
     SourceDocument,
+    SourceListResponse,
 )
 from app.services.catalog import count_passages_in_db, filter_sources, load_catalog
 from app.services.citation import CitationValidator

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from typing import Iterator
 
-from sqlmodel import SQLModel, Session, create_engine
+from sqlmodel import Session, SQLModel, create_engine
 
 from app.core.config import settings
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.core.config import settings
 from app.core.db import init_db
 from app.services.catalog import seed_catalog_to_db
 
+
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     init_db()

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -8,9 +8,9 @@ from typing import Dict, List, Optional
 
 from sqlmodel import select
 
+from app.core.config import settings
 from app.core.db import get_db_session
 from app.models import PassageModel, SourceDocumentModel
-from app.core.config import settings
 from app.schemas import Passage, SourceDocument
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=8.2.0",
+  "pytest-cov>=6.0.0",
   "pytest-asyncio>=0.23.0",
   "httpx>=0.27.0",
   "ruff>=0.6.0"
@@ -37,3 +38,6 @@ addopts = "-q"
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
+select = ["F", "I"]

--- a/scripts/smoke_backend.sh
+++ b/scripts/smoke_backend.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8000}"
+
+echo "[smoke] checking root"
+curl -fsS "$BASE_URL/" >/dev/null
+
+echo "[smoke] creating session"
+SESSION_ID=$(curl -fsS -X POST "$BASE_URL/v1/sessions" \
+  -H 'Content-Type: application/json' \
+  -d '{"preferred_language":"en","level":"beginner","goals":["smoke"]}' | python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')
+
+echo "[smoke] asking question"
+curl -fsS -X POST "$BASE_URL/v1/ask" \
+  -H 'Content-Type: application/json' \
+  -d "{\"session_id\":\"$SESSION_ID\",\"question\":\"What is wudu?\",\"preferred_language\":\"en\"}" >/dev/null
+
+echo "[smoke] retrieval health"
+curl -fsS "$BASE_URL/v1/health/retrieval" >/dev/null
+
+echo "[smoke] passed"


### PR DESCRIPTION
## Summary
- run backend lint + coverage in CI
- add frontend build step in CI
- add local make targets for lint/coverage/smoke
- add backend smoke script for API sanity checks
- normalize import ordering after ruff adoption

## Validation
- `ruff check app tests`
- `pytest tests --cov=app --cov-report=term-missing -q`
- `npm run lint && npm run typecheck && npm run build`
- `BASE_URL=http://127.0.0.1:8000 ./scripts/smoke_backend.sh`